### PR TITLE
Update readings and sensor_info tables to use units

### DIFF
--- a/egauge/script/api_egauge.py
+++ b/egauge/script/api_egauge.py
@@ -75,7 +75,7 @@ def get_data_from_api(conn, sensor_id):
     """
     current_time = pendulum.now('Pacific/Honolulu')
     # The next lines of code before setting api_start_time used to be in their own function get_most_recent_timestamp_from_db()
-    purpose_sensors = conn.query(orm_egauge.SensorInfo.purpose_id, orm_egauge.SensorInfo.data_sensor_info_mapping, orm_egauge.SensorInfo.last_updated_datetime).\
+    purpose_sensors = conn.query(orm_egauge.SensorInfo.purpose_id, orm_egauge.SensorInfo.data_sensor_info_mapping, orm_egauge.SensorInfo.last_updated_datetime, orm_egauge.SensorInfo.units).\
         filter_by(sensor_id=sensor_id,is_active=True)
     last_updated_datetime = purpose_sensors[0].last_updated_datetime
     if last_updated_datetime:
@@ -147,7 +147,7 @@ def insert_readings_into_database(conn, readings, purpose_sensors):
                     column_name = columns[i+1]
                     # only insert column's reading if data_sensor_info_mapping matches column_name
                     if purpose_sensor.data_sensor_info_mapping == column_name:
-                        reading_row = orm_egauge.Readings(purpose_id=purpose_sensor.purpose_id, datetime=row_datetime, value=row_reading)
+                        reading_row = orm_egauge.Readings(purpose_id=purpose_sensor.purpose_id, datetime=row_datetime, value=row_reading, units=purpose_sensor.units)
                         conn.add(reading_row)
                         rows_inserted += 1
                         new_last_updated_datetime = row_datetime

--- a/egauge/script/orm_egauge.py
+++ b/egauge/script/orm_egauge.py
@@ -68,6 +68,7 @@ class Readings(BASE):
     datetime = Column(TIMESTAMP, primary_key=True)
     purpose_id = Column(Integer, primary_key=True)
     value = Column(DOUBLE_PRECISION)
+    units = Column(String)
 
 
 class SensorInfo(BASE):
@@ -82,7 +83,7 @@ class SensorInfo(BASE):
         sensor_type: string representing source of readings; e.g. egauge, webctrl, hobo
         is_active: boolean representing if script can request data from a sensor
         last_updated_datetime: used to keep track of datetime of last successfully inserted reading
-        unit: unit of readings
+        units: unit of readings
     """
     __tablename__ = 'sensor_info'
 
@@ -93,7 +94,7 @@ class SensorInfo(BASE):
     sensor_type = Column(String)
     is_active = Column(Boolean)
     last_updated_datetime = Column(TIMESTAMP)
-    unit = Column(String)
+    units = Column(String)
 
 
 class ErrorLog(BASE):

--- a/hobo/script/extract_hobo.py
+++ b/hobo/script/extract_hobo.py
@@ -77,8 +77,8 @@ def get_csv_from_folder_not_in_db(conn, csv_filename):
     # create a list of sensor_info_rows which will be used to iterate through each data_sensor_info_mapping in each csv_reading row in the insert...() function
     sensor_info_rows = []
     for data_sensor_info_mapping in csv_readings.columns[1:]:
-        purpose_id, last_updated_datetime = conn.query(orm_hobo.SensorInfo.purpose_id, orm_hobo.SensorInfo.last_updated_datetime).filter_by(sensor_id=sensor_id, data_sensor_info_mapping=data_sensor_info_mapping, is_active=True).first()[:2]
-        sensor_info_rows.append(orm_hobo.SensorInfo(data_sensor_info_mapping=data_sensor_info_mapping, purpose_id=purpose_id, last_updated_datetime=last_updated_datetime))
+        purpose_id, last_updated_datetime, units = conn.query(orm_hobo.SensorInfo.purpose_id, orm_hobo.SensorInfo.last_updated_datetime, orm_hobo.SensorInfo.units).filter_by(sensor_id=sensor_id, data_sensor_info_mapping=data_sensor_info_mapping, is_active=True).first()[:3]
+        sensor_info_rows.append(orm_hobo.SensorInfo(data_sensor_info_mapping=data_sensor_info_mapping, purpose_id=purpose_id, last_updated_datetime=last_updated_datetime, units=units))
     # # Units
     # timezone_units = [x.split(', ')[1] for x in timezone_units]
     # #Timezone needs no further pre-processing
@@ -146,7 +146,7 @@ def insert_csv_readings_into_db(conn, csv_readings, csv_metadata, csv_filename):
     if rows_returned > 0:
         for csv_reading in csv_readings.itertuples():
             for i in range(0, len(sensor_info_rows)):
-                reading_row = orm_hobo.Readings(datetime=csv_reading[1], purpose_id=sensor_info_rows[i].purpose_id, value=csv_reading[i+2])
+                reading_row = orm_hobo.Readings(datetime=csv_reading[1], purpose_id=sensor_info_rows[i].purpose_id, value=csv_reading[i+2], units=sensor_info_rows[i].units)
                 conn.add(reading_row)
             last_reading_row_datetime = csv_reading[1]
     #update last_updated_datetime column for relevant rows in sensor_info table

--- a/hobo/script/orm_hobo.py
+++ b/hobo/script/orm_hobo.py
@@ -65,6 +65,7 @@ class Readings(BASE):
     datetime = Column(TIMESTAMP, primary_key=True)
     purpose_id = Column(Integer, primary_key=True)
     value = Column(DOUBLE_PRECISION)
+    units = Column(String)
 
 
 class SensorInfo(BASE):
@@ -79,7 +80,7 @@ class SensorInfo(BASE):
         sensor_type: string representing source of readings; e.g. egauge, webctrl, hobo
         is_active: boolean representing if script can request data from a sensor
         last_updated_datetime: used to keep track of datetime of last successfully inserted reading
-        unit: unit of readings
+        units: unit of readings
     """
     __tablename__ = 'sensor_info'
 
@@ -90,7 +91,7 @@ class SensorInfo(BASE):
     sensor_type = Column(String)
     is_active = Column(Boolean)
     last_updated_datetime = Column(TIMESTAMP)
-    unit = Column(String)
+    units = Column(String)
 
 
 class ErrorLog(BASE):

--- a/webctrl/script/api_webctrl.py
+++ b/webctrl/script/api_webctrl.py
@@ -115,7 +115,7 @@ def insert_readings_into_database(conn, readings, sensor):
                 reading_value = reading[key]
         # subtract 10 hours from reading time for comparison because it's GMT and last_updated_datetime is GMT - 10
         if reading_time.subtract(hours=10) > pendulum.instance(sensor.last_updated_datetime):
-            reading_row = orm_webctrl.Readings(purpose_id=sensor.purpose_id, datetime=reading_time, value=reading_value)
+            reading_row = orm_webctrl.Readings(purpose_id=sensor.purpose_id, datetime=reading_time, value=reading_value, units=sensor.units)
             conn.add(reading_row)
             rows_inserted += 1
             new_last_updated_datetime = reading_time
@@ -154,7 +154,7 @@ def log_failure_to_connect_to_database(conn, exception, sensor):
 if __name__ == '__main__':
     # connect to the database
     conn = get_db_handler()
-    sensors = conn.query(orm_webctrl.SensorInfo.purpose_id, orm_webctrl.SensorInfo.sensor_id, orm_webctrl.SensorInfo.last_updated_datetime).filter_by(sensor_type=orm_webctrl.SensorType.webctrl, is_active=True)
+    sensors = conn.query(orm_webctrl.SensorInfo.purpose_id, orm_webctrl.SensorInfo.sensor_id, orm_webctrl.SensorInfo.last_updated_datetime, orm_webctrl.SensorInfo.units).filter_by(sensor_type=orm_webctrl.SensorType.webctrl, is_active=True)
     for sensor in sensors:
         try:
             readings = get_data_from_api(sensor, conn)

--- a/webctrl/script/orm_webctrl.py
+++ b/webctrl/script/orm_webctrl.py
@@ -67,6 +67,7 @@ class Readings(BASE):
     datetime = Column(TIMESTAMP, primary_key=True)
     purpose_id = Column(Integer, primary_key=True)
     value = Column(DOUBLE_PRECISION)
+    units = Column(String)
 
 
 class SensorInfo(BASE):
@@ -81,7 +82,7 @@ class SensorInfo(BASE):
         sensor_type: string representing source of readings; e.g. egauge, webctrl, hobo
         is_active: boolean representing if script can request data from a sensor
         last_updated_datetime: used to keep track of datetime of last successfully inserted reading
-        unit: unit of readings
+        units: unit of readings
     """
     __tablename__ = 'sensor_info'
 
@@ -92,7 +93,7 @@ class SensorInfo(BASE):
     sensor_type = Column(String)
     is_active = Column(Boolean)
     last_updated_datetime = Column(TIMESTAMP)
-    unit = Column(String)
+    units = Column(String)
 
 
 class ErrorLog(BASE):


### PR DESCRIPTION
- added ```units``` to __readings__ table
- renamed ```unit``` to ```units``` in __sensor_info__ table to match current production database
- scripts now retrieve each purpose's ```units``` along with the rest of the necessary columns from __sensor_info__ and insert those ```units``` with their rows in __readings__