### PR TITLE
Add upload timestamp

### DIFF
--- a/egauge/script/orm_egauge.py
+++ b/egauge/script/orm_egauge.py
@@ -8,6 +8,7 @@ from sqlalchemy import create_engine
 from sqlalchemy import Boolean, Column, Integer, String
 from sqlalchemy.dialects.postgresql import DOUBLE_PRECISION, TIMESTAMP
 from sqlalchemy.ext.declarative import declarative_base
+from sqlalchemy.sql import func
 # from sqlalchemy.schema import ForeignKey
 
 import configparser
@@ -69,6 +70,7 @@ class Readings(BASE):
     purpose_id = Column(Integer, primary_key=True)
     value = Column(DOUBLE_PRECISION)
     units = Column(String)
+    upload_timestamp = Column(TIMESTAMP, default=func.now())
 
 
 class SensorInfo(BASE):

--- a/hobo/script/orm_hobo.py
+++ b/hobo/script/orm_hobo.py
@@ -7,6 +7,7 @@ from sqlalchemy import create_engine
 from sqlalchemy import Boolean, Column, Integer, String
 from sqlalchemy.dialects.postgresql import DOUBLE_PRECISION, TIMESTAMP
 from sqlalchemy.ext.declarative import declarative_base
+from sqlalchemy.sql import func
 
 import configparser
 # import csv
@@ -66,6 +67,7 @@ class Readings(BASE):
     purpose_id = Column(Integer, primary_key=True)
     value = Column(DOUBLE_PRECISION)
     units = Column(String)
+    upload_timestamp = Column(TIMESTAMP, default=func.now())
 
 
 class SensorInfo(BASE):

--- a/webctrl/script/orm_webctrl.py
+++ b/webctrl/script/orm_webctrl.py
@@ -8,6 +8,7 @@ from sqlalchemy import Boolean, Column, Integer, String
 from sqlalchemy.dialects.postgresql import DOUBLE_PRECISION, TIMESTAMP
 from sqlalchemy.ext.declarative import declarative_base
 # from sqlalchemy.schema import ForeignKey
+from sqlalchemy.sql import func
 
 import configparser
 # import csv
@@ -68,6 +69,7 @@ class Readings(BASE):
     purpose_id = Column(Integer, primary_key=True)
     value = Column(DOUBLE_PRECISION)
     units = Column(String)
+    upload_timestamp = Column(TIMESTAMP, default=func.now())
 
 
 class SensorInfo(BASE):


### PR DESCRIPTION
Eileen requested that the reading table also has a upload_timestamp just like scrape-util does. Error_log upload timestamps are insufficient for her needs, as she can't do queries using the upload_timestamp for each reading.